### PR TITLE
fix(): handle dates gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The following types are supported:
 - `z.boolean()` for boolean inputs
 - `z.number()` for numeric inputs (supports defining a range with `.min()` and `.max()`)
 - `z.string()` for string inputs
-- `z.string().date()` for date inputs
+- `z.coerce().date()` for date inputs
 - `z.union([z.literal(number), z.literal(number), ...])` for numeric inputs with a fixed set of options
 - `z.union([z.literal(string), z.literal(string), ...])` for string inputs with a fixed set of options
 - `z.array(z.union([z.literal(number), z.literal(number), ...]))` for numeric arrays with a fixed set of options

--- a/scripts/generate-score.mjs
+++ b/scripts/generate-score.mjs
@@ -1997,7 +1997,7 @@ import { ScoreInputSchemaType } from '../../../types'
 
 export const AGE_CALC_INPUTS = {
   date_of_birth: {
-    type: z.string().date(),
+    type: z.coerce().date(),
     label: {
       nl: 'Geboortedatum',
       en: 'Date of Birth',

--- a/src/classes/__tests__/ScoreClass.test.ts
+++ b/src/classes/__tests__/ScoreClass.test.ts
@@ -23,7 +23,7 @@ const createScore = (inputSchema?: ScoreInputSchemaType) => {
           ],
         },
       },
-      dateInput: { type: z.string().date().optional() },
+      dateInput: { type: z.coerce.date().optional() },
       stringInput: { type: z.string().optional() },
       enumStringInput: {
         type: z

--- a/src/lib/castFunctions/tryCastInputsToExactTypes.test.ts
+++ b/src/lib/castFunctions/tryCastInputsToExactTypes.test.ts
@@ -17,7 +17,7 @@ describe('Casting inputs to exact types', () => {
         ],
       },
     },
-    dateInput: { type: z.string().date().optional() },
+    dateInput: { type: z.coerce.date().optional() },
     stringInput: { type: z.string().optional() },
     enumStringInput: {
       type: z

--- a/src/lib/parseToApiSchema/awell/schema/lib/inputSchemaToApiInputSchema/inputSchemaToApiInputSchema.test.ts
+++ b/src/lib/parseToApiSchema/awell/schema/lib/inputSchemaToApiInputSchema/inputSchemaToApiInputSchema.test.ts
@@ -68,7 +68,7 @@ describe('inputSchemaToApiInputSchema', () => {
       const inputSchema = {
         inputId: {
           label: { en: 'inputId' },
-          type: z.string().date().optional(),
+          type: z.coerce.date().optional(),
         },
       }
       const result = inputSchemaToApiInputSchema(inputSchema)

--- a/src/lib/parseToApiSchema/awell/schema/lib/inputSchemaToApiInputSchema/inputSchemaToApiInputSchema.ts
+++ b/src/lib/parseToApiSchema/awell/schema/lib/inputSchemaToApiInputSchema/inputSchemaToApiInputSchema.ts
@@ -134,23 +134,23 @@ export const inputSchemaToApiInputSchema = (
     }
 
     if (inputType instanceof z.ZodString) {
-      const isDate = inputType._def.checks.find(check => check.kind === 'date')
-      if (isDate) {
-        jsonSchema[key] = {
-          ...baseJson,
-          input_type: {
-            type: 'date',
-            required: !isOptional,
-          },
-        }
-      } else {
-        jsonSchema[key] = {
-          ...baseJson,
-          input_type: {
-            type: 'string',
-            required: !isOptional,
-          },
-        }
+      jsonSchema[key] = {
+        ...baseJson,
+        input_type: {
+          type: 'string',
+          required: !isOptional,
+        },
+      }
+      continue
+    }
+
+    if (inputType instanceof z.ZodDate) {
+      jsonSchema[key] = {
+        ...baseJson,
+        input_type: {
+          type: 'date',
+          required: !isOptional,
+        },
       }
       continue
     }

--- a/src/lib/simulation/simulateScoreInput.test.ts
+++ b/src/lib/simulation/simulateScoreInput.test.ts
@@ -18,7 +18,7 @@ const inputSchema = createZodObjectFromSchema({
       ],
     },
   },
-  dateInput: { type: z.string().date().optional() },
+  dateInput: { type: z.coerce.date().optional() },
   stringInput: { type: z.string().optional() },
   enumStringInput: {
     type: z

--- a/src/lib/simulation/simulateScoreInput.ts
+++ b/src/lib/simulation/simulateScoreInput.ts
@@ -23,12 +23,11 @@ export const simulateScoreInput = <InputSchema extends ScoreInputSchemaType>(
     const inputType = getZodType()
 
     if (inputType instanceof z.ZodString) {
-      const isDate = inputType._def.checks.find(check => check.kind === 'date')
-      if (isDate) {
-        return simulateDateInput()
-      }
-
       return simulateStringInput()
+    }
+
+    if (inputType instanceof z.ZodDate) {
+      return simulateDateInput()
     }
 
     if (inputType instanceof z.ZodBoolean) {

--- a/src/scores/age_calc/age_calc.test.ts
+++ b/src/scores/age_calc/age_calc.test.ts
@@ -41,16 +41,34 @@ describe('age_calc', function () {
   })
 
   describe('each calculated score shall include the correct formula and output the correct result', function () {
-    it('should return correct result age', function () {
-      const dob = '1993-11-30'
-      MockDate.set('2025-01-01T00:00:00Z')
-      const EXPECTED_AGE = 31
+    describe('when input date is just a date string', () => {
+      it('should return correct result age', function () {
+        const dob = '1993-11-30'
+        MockDate.set('2025-01-01T00:00:00Z')
 
-      const result = calculate_age.calculate({
-        payload: { date_of_birth: '1993-11-30' },
+        const EXPECTED_AGE = 31
+
+        const result = calculate_age.calculate({
+          payload: { date_of_birth: dob },
+        })
+
+        expect(result.AGE).toEqual(EXPECTED_AGE)
       })
+    })
 
-      expect(result.AGE).toEqual(EXPECTED_AGE)
+    describe('when input date is just a datetime string', () => {
+      it('should return correct result age', function () {
+        const dob = '1993-11-30T00:00:00.000Z'
+        MockDate.set('2025-01-01T00:00:00Z')
+
+        const EXPECTED_AGE = 31
+
+        const result = calculate_age.calculate({
+          payload: { date_of_birth: dob },
+        })
+
+        expect(result.AGE).toEqual(EXPECTED_AGE)
+      })
     })
   })
 })

--- a/src/scores/age_calc/age_calc.ts
+++ b/src/scores/age_calc/age_calc.ts
@@ -10,14 +10,13 @@ export const age_calc: ScoreType<
   inputSchema: AGE_CALC_INPUTS,
   outputSchema: AGE_CALC_OUTPUT,
   calculate: ({ data }) => {
-    const dateOfBirth = new Date(data.date_of_birth)
     const today = new Date()
 
-    const age = today.getFullYear() - dateOfBirth.getFullYear()
+    const age = today.getFullYear() - data.date_of_birth.getFullYear()
     const isBirthdayPassed =
-      today.getMonth() > dateOfBirth.getMonth() ||
-      (today.getMonth() === dateOfBirth.getMonth() &&
-        today.getDate() >= dateOfBirth.getDate())
+      today.getMonth() > data.date_of_birth.getMonth() ||
+      (today.getMonth() === data.date_of_birth.getMonth() &&
+        today.getDate() >= data.date_of_birth.getDate())
 
     const adjustedAge = isBirthdayPassed ? age : age - 1
 

--- a/src/scores/age_calc/definition/age_calc_inputs.ts
+++ b/src/scores/age_calc/definition/age_calc_inputs.ts
@@ -3,7 +3,7 @@ import { ScoreInputSchemaType } from '../../../types'
 
 export const AGE_CALC_INPUTS = {
   date_of_birth: {
-    type: z.string().date(),
+    type: z.coerce.date(),
     label: {
       nl: 'Geboortedatum',
       en: 'Date of Birth',

--- a/src/scores/test_calculation/test_caculation.ts
+++ b/src/scores/test_calculation/test_caculation.ts
@@ -16,7 +16,7 @@ const inputSchema = {
       ],
     },
   },
-  dateInput: { type: z.string().date().optional() },
+  dateInput: { type: z.coerce.date().optional() },
   stringInput: { type: z.string().optional() },
   enumStringInput: {
     type: z


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Replace string date with coerce date conversion.

- Adjust tests for multiple date input formats.

- Fix age calculation using proper date type.

- Update documentation and score generation script.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>ScoreClass.test.ts</strong><dd><code>Use z.coerce.date() for dateInput in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-ea22f008d5de78944e08f4a0cf8d7a9fdae644ba061da9f8d51e547878663157">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tryCastInputsToExactTypes.test.ts</strong><dd><code>Convert dateInput to use z.coerce.date() in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-0bcfa76581ebdfb05fe7ddb27d7d49d29cd3cf5d47cc460587e4551ca0bed03f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inputSchemaToApiInputSchema.test.ts</strong><dd><code>Update date schema tests to use coerce date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-c3252fd39dee2d7f60dad2bcb49bce5c17c4cde7c5363c20d7f9f43901922148">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inputSchemaToApiInputSchema.ts</strong><dd><code>Simplify logic by removing z.string().date() check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-e02e3a70ce9b06b9d9050df4ab9e7244fb9ff42d4e3953f06490103d2b313383">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>simulateScoreInput.test.ts</strong><dd><code>Change dateInput to coerce date type in simulation tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-a86b9a8d4da16cf955c04cf8f188d5d7b1713e76704753aa1b1e1ac16ee15d83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>simulateScoreInput.ts</strong><dd><code>Introduce ZodDate check for date simulation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-436280a429cfeb2198e624945ced48080a7154a2b48314bd4dbb25e08ba43d38">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>age_calc.test.ts</strong><dd><code>Enhance tests with date string and datetime cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-376c904d75fbf877eda8361db6e059a39c2cf7aebecc689093ac511a25897186">+25/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>age_calc.ts</strong><dd><code>Adjust age calculation to use date input directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-b6322d2adc7ff233a2bdaaab97efb81854086dfbf58e66ca11d2dcf38d90f9a9">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>age_calc_inputs.ts</strong><dd><code>Update input schema to use z.coerce.date()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-65d79d83e2cce199f7c5f894e53ae7ea39673f8c2a65e9a0edfec6460ce5e5b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_caculation.ts</strong><dd><code>Replace z.string().date() with z.coerce.date() in tests</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-9664ac2bc3219688cabeb82dac33adbb001f6d367b286634802d98239828dafd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate-score.mjs</strong><dd><code>Update score generation to use z.coerce().date()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-08dc5d8c41d4e2462056e4dc2e89d0dd1850b7054c11963ec6fe18fceec700cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Revise date input documentation to use coerce date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/awell-health/awell-score/pull/59/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>