### PR TITLE
docs: clarify that MIT licence covers code, not instrument content

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,8 @@
+The MIT licence below applies to the software in this repository. It does not
+apply to third-party clinical instrument content. See NOTICE.
+
+---
+
 The MIT License (MIT)
 
 Copyright (c) Awell

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+This repository implements scoring logic for clinical assessment instruments.
+Many such instruments are protected by copyright held by their authors or
+publishers, and some require a licence or fee for use.
+
+Awell makes no claim of ownership over instrument content including item text,
+question labels, response options, scoring anchors, and interview prompts, and
+grants no rights to it. The MIT licence covers Awell's source code only.
+
+Determining whether a licence is required for a given instrument, and obtaining
+it, is the responsibility of the party using that instrument.
+
+Reporting a rights concern: if you hold rights to content in this repository and
+believe it is published without authorisation, contact support@awellhealth.com. We remove content
+on notice while the position is clarified.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 - **📏 Reliability and validity**: Open peer review ensures high-quality, clinically assured calculations.
 - **🧑‍🤝‍🧑 Collaboration**: Contribute to and benefit from a shared knowledge base.
 
+## ⚖️ Licence scope
+
+This repository's code is MIT licensed. Clinical instrument content (item text, question labels, response options, scoring anchors, interview prompts) is not covered by that licence and may be subject to third-party copyright. See [NOTICE](./NOTICE) for details.
+
 ## Contents
 
 - [Background](#-background)


### PR DESCRIPTION
## Summary
- Added a short note above the MIT text in `LICENSE.md` clarifying that the licence applies to the repository's software only, not to third-party clinical instrument content. The MIT licence text itself is unchanged.
- Added `NOTICE` at the repo root explaining that Awell makes no ownership claim over instrument content (item text, question labels, response options, scoring anchors, interview prompts), and how to report a rights concern.
- Added a short "Licence scope" section to `README.md`, placed after the intro/key-benefits and before the Contents/Installation sections, linking to `NOTICE`. Visible without scrolling on GitHub.

## Notes
- `package.json`'s `license` field is currently `"ISC"`, which doesn't match `LICENSE.md` (MIT) or the README's stated licence. That mismatch pre-dates this PR and wasn't changed here, since correcting it wasn't part of the requested scope — flagging it in case it should be addressed separately.
- No instruments are asserted to be public domain or licence-free; the disclaimer is deliberately non-committal on a per-instrument basis.

Not merging — for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUJcSrwwwhiRwkaRjRq8tv)_