### PR TITLE
feat: add optional licensing_status to instrument definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added optional `licensing_status` and `license_contact` fields to instrument
+  definitions and the API schema output (`apiSchema`). Both are additive and
+  default to `unknown` / `null` respectively when omitted; existing definitions
+  and consumers are unaffected. Note: consumers using a strict/closed JSON
+  Schema validator (`additionalProperties: false`) against the API response
+  will need to account for these two new keys.
 - Removed PANSS-family instruments. Instrument content is subject to third-party
   copyright and licensing; scoring for these instruments is not available in this
   library. Users requiring these instruments should obtain them from the rights holder.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A score definition may optionally set two fields describing the licensing status
 - `licensing_status`: one of `public_domain`, `free_with_attribution`, `license_required`, or `unknown`. Defaults to `unknown` when omitted.
 - `license_contact`: an optional contact or reference for licensing questions. Defaults to `null` when omitted.
 
-Only set `licensing_status` to a value other than `unknown` if you can point to a verifiable source for that instrument's licensing terms. Do not guess — leaving it `unknown` is always safer than an incorrect status.
+Only set `licensing_status` to a value other than `unknown` if you can point to a verifiable source for that instrument's licensing terms. Do not guess — leaving it `unknown` is always safer than an incorrect status. See [NOTICE](./NOTICE) for background.
 
 ## 🪪 License policy
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ The calculate function is a function that takes the input data and returns the o
 
 It always needs to return an object with the same keys as the output schema and values of the correct types. However, the value can also be set to `null` if the score cannot be calculated.
 
+#### Licensing status
+
+A score definition may optionally set two fields describing the licensing status of the underlying instrument (not the Awell Score source code, which is always MIT licensed):
+
+- `licensing_status`: one of `public_domain`, `free_with_attribution`, `license_required`, or `unknown`. Defaults to `unknown` when omitted.
+- `license_contact`: an optional contact or reference for licensing questions. Defaults to `null` when omitted.
+
+Only set `licensing_status` to a value other than `unknown` if you can point to a verifiable source for that instrument's licensing terms. Do not guess — leaving it `unknown` is always safer than an incorrect status.
+
 ## 🪪 License policy
 
 Awell Score is open-source and supports various clinical questionnaires. Some questionnaires may have licensing requirements. Users are responsible for ensuring they hold the appropriate licenses. We do not manage or provide these licenses. Misuse of licensed questionnaires is the sole responsibility of the user.

--- a/src/classes/Score.ts
+++ b/src/classes/Score.ts
@@ -6,6 +6,8 @@ import {
   type CalculateFn,
   type TerminologyType,
   type AvailableLanguagesType,
+  type LicensingStatusType,
+  LICENSING_STATUS_VALUES,
 } from '../types'
 import {
   parseReadmeToHtml,
@@ -64,6 +66,18 @@ export class Score<
   terminology: TerminologyType | undefined
 
   /**
+   * Licensing status of the underlying clinical instrument. Defaults to
+   * 'unknown' when the definition omits it.
+   */
+  licensing_status: LicensingStatusType
+
+  /**
+   * Contact/reference for licensing questions about the underlying
+   * instrument. Defaults to null when the definition omits it.
+   */
+  license_contact: string | null
+
+  /**
    * The function to calculate the score.
    */
   private _calculate: CalculateFn<
@@ -96,6 +110,15 @@ export class Score<
     this.inputSchema = score.inputSchema
     this.outputSchema = score.outputSchema
     this.terminology = score.terminology
+    this.licensing_status = z
+      .enum(LICENSING_STATUS_VALUES)
+      .default('unknown')
+      .parse(score.licensing_status)
+    this.license_contact = z
+      .string()
+      .nullable()
+      .default(null)
+      .parse(score.license_contact)
     this._calculate = score.calculate
     this.inputSchemaAsObject = createZodObjectFromSchema(this.inputSchema)
   }
@@ -242,6 +265,8 @@ export class Score<
       inputSchema: this.inputSchema,
       outputSchema: this.outputSchema,
       terminology: this.terminology,
+      licensing_status: this.licensing_status,
+      license_contact: this.license_contact,
     })
   }
 }

--- a/src/classes/__tests__/ScoreClass.test.ts
+++ b/src/classes/__tests__/ScoreClass.test.ts
@@ -1,13 +1,24 @@
 import { z, ZodError } from 'zod'
 import { Score } from '../Score'
 import { CalculationResultStatus } from '../../lib/parseToApiSchema/awell/result/parseToApiResultFormat/types'
-import { type ScoreInputSchemaType } from '../../types'
+import {
+  LICENSING_STATUS_VALUES,
+  type LicensingStatusType,
+  type ScoreInputSchemaType,
+} from '../../types'
 
-const createScore = (inputSchema?: ScoreInputSchemaType) => {
+const createScore = (
+  inputSchema?: ScoreInputSchemaType,
+  extra?: {
+    licensing_status?: LicensingStatusType
+    license_contact?: string | null
+  },
+) => {
   return new Score({
     id: 'test_score',
     name: 'Test Score',
     readmeLocation: __dirname,
+    ...extra,
     inputSchema: inputSchema || {
       simpleNumberInput: { type: z.number().optional() },
       simpleNumberInputWithRange: {
@@ -341,7 +352,40 @@ describe('Score', () => {
             },
           ],
         },
+        licensing_status: 'unknown',
+        license_contact: null,
       })
+    })
+  })
+
+  describe('Licensing status', () => {
+    test('defaults to "unknown" when the definition omits licensing_status', () => {
+      expect(createScore().licensing_status).toBe('unknown')
+    })
+
+    test.each(LICENSING_STATUS_VALUES)('accepts "%s" as a valid value', value => {
+      expect(
+        createScore(undefined, { licensing_status: value }).licensing_status,
+      ).toBe(value)
+    })
+
+    test('rejects a value outside the allowed list', () => {
+      const invalidStatus = 'not_a_real_status' as unknown as LicensingStatusType
+
+      expect(() =>
+        createScore(undefined, { licensing_status: invalidStatus }),
+      ).toThrow(ZodError)
+    })
+
+    test('license_contact defaults to null when the definition omits it', () => {
+      expect(createScore().license_contact).toBeNull()
+    })
+
+    test('license_contact keeps an explicit string value', () => {
+      expect(
+        createScore(undefined, { license_contact: 'licensing@example.com' })
+          .license_contact,
+      ).toBe('licensing@example.com')
     })
   })
 

--- a/src/lib/parseToApiSchema/awell/schema/parseToAwellApiSchema.ts
+++ b/src/lib/parseToApiSchema/awell/schema/parseToAwellApiSchema.ts
@@ -2,6 +2,7 @@ import {
   TerminologyType,
   type ScoreInputSchemaType,
   type ScoreOutputSchemaType,
+  type LicensingStatusType,
 } from '../../../../types'
 import { type ApiScoreType } from './types'
 import { inputSchemaToApiInputSchema } from './lib/inputSchemaToApiInputSchema/inputSchemaToApiInputSchema'
@@ -14,6 +15,8 @@ export const parseToAwellApiSchema = ({
   inputSchema,
   outputSchema,
   terminology,
+  licensing_status,
+  license_contact,
 }: {
   scoreId: string
   scoreName: string
@@ -21,6 +24,8 @@ export const parseToAwellApiSchema = ({
   inputSchema: ScoreInputSchemaType
   outputSchema: ScoreOutputSchemaType
   terminology?: TerminologyType
+  licensing_status: LicensingStatusType
+  license_contact: string | null
 }): ApiScoreType => {
   const DEFAULT_SCORE_TERMINOLOGY = {
     category: [
@@ -47,5 +52,7 @@ export const parseToAwellApiSchema = ({
       output_definition: outputSchemaToApiOutputSchema(outputSchema),
     },
     terminology: terminology ?? DEFAULT_SCORE_TERMINOLOGY,
+    licensing_status,
+    license_contact,
   }
 }

--- a/src/lib/parseToApiSchema/awell/schema/types.ts
+++ b/src/lib/parseToApiSchema/awell/schema/types.ts
@@ -1,4 +1,9 @@
-import { CodeType, TerminologyType, type LabelType } from '../../../../types'
+import {
+  CodeType,
+  TerminologyType,
+  type LabelType,
+  type LicensingStatusType,
+} from '../../../../types'
 
 interface BooleanInputApiType {
   type: 'boolean'
@@ -97,4 +102,6 @@ export interface ApiScoreType {
     output_definition: Array<ApiOutputType>
   }
   terminology?: TerminologyType
+  licensing_status: LicensingStatusType
+  license_contact: string | null
 }

--- a/src/types/Score.types.ts
+++ b/src/types/Score.types.ts
@@ -17,6 +17,21 @@ export interface TerminologyType {
   code?: CodeType & { text?: string }
 }
 
+/**
+ * Licensing status of the underlying clinical instrument (not the Awell Score
+ * source code, which is always MIT licensed). Defaults to 'unknown' when a
+ * definition omits it. Never inferred or guessed — only set when a verifiable
+ * source confirms the status.
+ */
+export const LICENSING_STATUS_VALUES = [
+  'public_domain',
+  'free_with_attribution',
+  'license_required',
+  'unknown',
+] as const
+
+export type LicensingStatusType = (typeof LICENSING_STATUS_VALUES)[number]
+
 export type ScoreType<
   InputSchema extends ScoreInputSchemaType = ScoreInputSchemaType,
   OutputSchema extends ScoreOutputSchemaType = ScoreOutputSchemaType,
@@ -26,6 +41,8 @@ export type ScoreType<
   inputSchema: InputSchema
   outputSchema: OutputSchema
   terminology?: TerminologyType
+  licensing_status?: LicensingStatusType
+  license_contact?: string | null
   calculate: CalculateFn<
     z.ZodObject<{ [K in keyof InputSchema]: InputSchema[K]['type'] }>,
     OutputSchema


### PR DESCRIPTION
## Investigation (before writing code)

1. **Validation location**: the "instrument/calculation definition" is the `ScoreType` object (`src/types/Score.types.ts`). It's validated only at **compile time** via TypeScript — there's no runtime/Zod validation of the `ScoreType` shell itself (only the calculation *payload* is Zod-validated, against `inputSchema`). One schema location, one runtime validation path (payloads only).
2. **Generated types**: none. No JSON Schema/OpenAPI/Pydantic generation in this repo — it's TS-only, and the API-shaped output (`ApiScoreType`) is a hand-maintained TS interface built at runtime, not a checked-in generated artifact.
3. **Consumers that could break on a new field**: `library.ts` spreads score objects into `new Score(...)` (safe). The `Score` constructor destructures known fields explicitly rather than spreading onto `this` (safe — no field propagates automatically, everything had to be wired in). **One real risk found**: `src/classes/__tests__/ScoreClass.test.ts`'s "API schema" test does `expect(defaultScore.apiSchema).toEqual({...fully enumerated object...})` — a full deep-equality assertion. Adding two new always-present keys to `apiSchema` breaks this unless updated. No other deep-equality/hash/cache consumer found.
4. **Snapshot/golden tests**: no `.snap` files exist anywhere in the repo. The `toEqual` test above is the only golden-style risk.
5. **Persistence/cache**: none — no database, cache layer, or migration tooling anywhere in `src/`. Stateless library.

Nothing in 3–5 blocks a purely additive change — only the one `toEqual` test needed updating (see below).

## Changes
- `src/types/Score.types.ts`: added `LICENSING_STATUS_VALUES` (`public_domain | free_with_attribution | license_required | unknown`), `LicensingStatusType`, and two new **optional** fields on `ScoreType`: `licensing_status?` and `license_contact?`.
- `src/classes/Score.ts`: resolves defaults at read time in the constructor (`licensing_status` defaults to `'unknown'` via `z.enum(...).default('unknown').parse(...)`; `license_contact` defaults to `null` via `z.string().nullable().default(null).parse(...)`). Invalid values throw `ZodError`, consistent with existing input-validation behavior. No definition files were touched — the default is never written back to disk.
- `src/lib/parseToApiSchema/awell/schema/{parseToAwellApiSchema.ts,types.ts}`: the two resolved fields now flow into `apiSchema`/`ApiScoreType`, appended after `terminology` (existing key order unchanged).
- `src/classes/__tests__/ScoreClass.test.ts`: updated the one `toEqual` full-object "API schema" test to include the two new default keys (`licensing_status: 'unknown', license_contact: null`) — this is the one required, explained change; not a blind snapshot update, and no `.snap` files exist to regenerate. Added a new `describe('Licensing status')` block covering: default resolves to `unknown` when omitted, each of the four values validates, an invalid value throws `ZodError`, and `license_contact` defaults to `null` / keeps an explicit string.
- `README.md`: added contributor documentation for the two new fields, explicitly instructing not to guess a licensing status — leave it `unknown` unless a verifiable source confirms otherwise. Not enforced via required schema fields or a custom lint rule — the repo's ESLint config has no custom-rule infrastructure to hang a check on ("if CI conventions already support it" — they don't), so enforcement is documentation-only per the task's instructions.
- No score definition files (`src/scores/**/*.ts`) were modified. Every one of the ~166 existing definitions omits both fields and resolves to `unknown`/`null` via the default.

## Backward-compatibility verification
- Full suite: **166 suites / 3130 tests, 0 failures, 0 snapshots** (none exist in this repo).
- `yarn build` succeeds; the emitted `.d.ts` shows both new fields as optional (`licensing_status?: LicensingStatusType; license_contact?: string | null;`) — downstream TypeScript consumers compile unchanged.
- Every existing score definition instantiates and validates without modification (confirmed via the full suite, which imports `ScoreLibrary` — all ~166 scores construct successfully with the field absent).
- API response (`apiSchema`) key order for existing keys is unchanged; the two new keys are appended at the end. No type change, removal, or null-vs-absent change anywhere else in the payload.
- No default value was written back into any definition file on disk — defaults resolve at `Score` construction (read) time only.

## Flag for discussion
Adding fields to `apiSchema`'s output is additive for tolerant consumers, but **any downstream consumer using a strict/closed JSON Schema validator (`additionalProperties: false`) against this API response will break** on the two new always-present keys. Worth deciding whether this needs a version/changelog note for API consumers before release.

Not merging — for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUJcSrwwwhiRwkaRjRq8tv)_