### PR TITLE
chore: automate release candidates and document releasing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Verify release tag matches package.json version
+        run: |
+          tag=${GITHUB_REF##*/}
+          pkg=$(jq -r .version package.json)
+          if [ "$tag" != "v$pkg" ]; then
+            echo "::error::tag $tag does not match package.json version $pkg. See RELEASING.md."
+            exit 1
+          fi
+
       - name: Enable Corepack before setting up Node
         run: corepack enable
 
@@ -37,8 +46,16 @@ jobs:
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      # package.json is the source of truth and the step above proved it matches
+      # the tag, so there is nothing to rewrite here. Release candidates go to the
+      # `rc` dist-tag so that `npm install @awell-health/awell-score` keeps
+      # resolving to the latest stable version.
       - name: Publish to NPM Registry
         run: |
-          release_version=${GITHUB_REF##*/}
-          yarn version "$release_version"
-          yarn npm publish --access public
+          version=$(jq -r .version package.json)
+          case "$version" in
+            *-*) dist_tag=rc ;;
+            *)   dist_tag=latest ;;
+          esac
+          echo "Publishing $version to the $dist_tag dist-tag."
+          yarn npm publish --access public --tag "$dist_tag"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,99 @@ jobs:
 
       - name: Run tests
         run: yarn test
+
+  # Moves main to the next release candidate and leaves a draft GitHub Release
+  # ready in the Releases tab. Publishing that draft is what ships to npm — see
+  # RELEASING.md. If the push already set the version by hand (`yarn bump:minor`
+  # and friends), that version is respected instead of being bumped over.
+  release:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # main requires a pull request, and github-actions[bot] cannot be
+          # granted a bypass, so pushing the bump needs a token belonging to
+          # someone who can — see RELEASING.md. Falls back to the built-in token,
+          # which will fail the push on a protected branch.
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Bump to the next release candidate
+        id: bump
+        run: |
+          previous=$(git show "${{ github.event.before }}:package.json" 2>/dev/null | jq -r .version || true)
+          current=$(jq -r .version package.json)
+
+          if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
+            echo "::notice::This push set the version to $current by hand; leaving it as is."
+          else
+            npm version prerelease --preid rc --no-git-tag-version >/dev/null
+            current=$(jq -r .version package.json)
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            # [skip ci] matters when RELEASE_BOT_TOKEN is a PAT: unlike the
+            # built-in token, a PAT push retriggers workflows, and without this
+            # the bump would bump itself forever.
+            git commit -am "chore: bump version to v$current [skip ci]"
+            git push origin "HEAD:$GITHUB_REF_NAME"
+            echo "::notice::Bumped $previous -> $current."
+            echo "superseded=$previous" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          # The draft must point at the bump commit, not at the pushed commit —
+          # publish.yml checks the tag against package.json at the tagged commit.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          SHA: ${{ steps.bump.outputs.sha }}
+          SUPERSEDED: ${{ steps.bump.outputs.superseded }}
+        run: |
+          state() {
+            gh release list --limit 100 --json tagName,isDraft \
+              --jq ".[] | select(.tagName == \"$1\") | if .isDraft then \"draft\" else \"published\" end"
+          }
+
+          # The version we just bumped past never shipped, so its draft is stale.
+          if [ -n "$SUPERSEDED" ] && [ "$(state "v$SUPERSEDED")" = "draft" ]; then
+            gh release delete "v$SUPERSEDED" --yes
+            echo "Deleted superseded draft v$SUPERSEDED."
+          fi
+
+          tag="v$VERSION"
+          if [ "$(state "$tag")" = "published" ]; then
+            echo "::notice::$tag is already released; nothing to draft."
+            exit 0
+          fi
+
+          if [ "$(state "$tag")" = "draft" ]; then
+            # Notes are left alone so hand-written release notes survive.
+            gh release edit "$tag" --target "$SHA"
+            echo "::notice::Retargeted draft $tag at $SHA."
+            exit 0
+          fi
+
+          # A version with a hyphen is a release candidate; flag it so GitHub does
+          # not label it the latest release.
+          case "$VERSION" in
+            *-*) prerelease=--prerelease ;;
+            *)   prerelease= ;;
+          esac
+
+          # Body is the top section of the changelog; --generate-notes appends the
+          # merged-PR list underneath it.
+          gh release create "$tag" \
+            --draft $prerelease \
+            --target "$SHA" \
+            --title "$tag" \
+            --generate-notes \
+            --notes "$(awk '/^## /{n++; next} n==1' CHANGELOG.md)"
+          echo "::notice::Drafted $tag. Publish it to ship $VERSION to npm."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# Agent instructions
+
+`@awell-health/awell-score` is a library of scoring functions for clinical
+assessment instruments and PROMs. It is published to npm and consumed by
+`calculations-api` (`packages/api` in the GitLab `awellhealth/calculation-suite`
+repo), which is deployed through
+[release-management](https://release-management.awellhealth.com).
+
+## Start here
+
+| Task | Read |
+| --- | --- |
+| Cutting a release, bumping the version | **[RELEASING.md](./RELEASING.md)** |
+| Adding or changing a score | [README.md](./README.md#adding-a-new-score) and the anatomy below |
+| Anything touching instrument content | **[NOTICE](./NOTICE)** — read before adding item text |
+
+## Commands
+
+```bash
+yarn test                       # jest, whole suite (slow — see below)
+yarn test src/scores/audit      # one score's tests
+yarn lint                       # eslint
+yarn build                      # tsc + copy score READMEs into dist
+yarn bump                       # next release candidate, e.g. 1.1.8 -> 1.1.9-rc.0
+yarn bump:minor                 # 1.2.0-rc.0
+yarn bump:major                 # 2.0.0-rc.0
+yarn bump:release               # drop the rc suffix and cut stable
+```
+
+## Releasing, in one paragraph
+
+Pushing to `main` does **not** publish. A push runs the tests, then bumps
+`package.json` to the next release candidate, commits that, and leaves a draft
+GitHub Release. Publishing that draft is what ships to npm. The bump only happens
+when the push left the version alone, so running `yarn bump:minor` in your branch
+is how you choose a different bump — that is the entire override mechanism, and it
+belongs in the PR diff. `publish.yml` refuses to publish if the release tag and
+`package.json` disagree. Full detail, including the `RELEASE_BOT_TOKEN` secret and
+the `rc` dist-tag, is in [RELEASING.md](./RELEASING.md).
+
+## Instrument content and licensing
+
+This is the constraint most likely to cause real harm, so treat it as a hard rule.
+
+The MIT licence covers **Awell's code only**. Instrument content — item text,
+question labels, response options, scoring anchors, interview prompts — is often
+third-party copyright, sometimes requiring a paid licence. The PANSS family was
+removed from this repository for exactly this reason.
+
+- Do not add or reproduce instrument item text without a verifiable licence
+  permitting it. Scoring *logic* and *structure* are the deliverable here; verbatim
+  content is not.
+- `licensing_status` on a definition is one of `public_domain`,
+  `free_with_attribution`, `license_required`, `unknown`, and defaults to
+  `unknown`. **Never infer or guess it** — set it only from a verifiable source, and
+  leave it off when you do not have one. Same for `license_contact`.
+- If asked to add an instrument whose licensing you cannot establish, say so rather
+  than shipping it with `unknown` and moving on.
+
+## Anatomy of a score
+
+121 scores live in `src/scores/<score_name>/`:
+
+```
+src/scores/audit/
+  audit.ts             # the score, built with the SDK
+  audit.test.ts        # tests
+  definition/          # input/output schema, subscales
+  __testdata__/        # response fixtures (min, max, median, random)
+  README.md            # copied into dist by yarn build
+```
+
+A new score is not reachable until it is registered in
+[`src/scores/library.ts`](./src/scores/library.ts), which imports all 124 entries
+explicitly. `src/index.ts` exports `ScoreLibrary` from there.
+
+Test fixtures conventionally cover minimum, maximum, median and random responses;
+follow the neighbouring score's shape rather than inventing a new one.
+
+## Changelog
+
+Add entries under `## Unreleased` in [CHANGELOG.md](./CHANGELOG.md). Releasing
+renames that heading to the version number — see RELEASING.md. Call out anything
+that changes the shape of `apiSchema` output, since consumers validate against it.
+
+## Known gotcha: the test suite is slow
+
+A single test file takes roughly 9 seconds locally, and almost none of that is
+the test. Measured:
+
+| A test file that imports | Time |
+| --- | --- |
+| nothing | 2.1s |
+| one score module | 3.0s |
+| `ScoreLibrary` | 6.7s |
+
+Nearly every test imports `ScoreLibrary` to look its own score up, and
+`library.ts` imports all 124 scores — so each of the 166 test files loads and
+type-checks the entire graph, in every jest worker, with no shared cache. On top of
+that, `jest.config.cjs` uses `preset: 'ts-jest'` with type-checking left on, which
+accounts for about 40% of the per-file cost.
+
+Practical consequences for you:
+
+- Run the single score's tests while iterating (`yarn test src/scores/audit`), not
+  the whole suite.
+- Do not conclude the suite has hung. It is just slow.
+- Importing `ScoreLibrary` in a new test costs ~4s. If the test only needs one
+  score, import that score directly.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository's code is MIT licensed. Clinical instrument content (item text, 
 - [Background](#-background)
 - [Installation and usage](#-documentation)
 - [How to Contribute](#-how-to-contribute)
+- [Releasing](./RELEASING.md)
 - [License policy](#-license-policy)
 
 ## 📜 Background
@@ -99,6 +100,8 @@ console.log(simulation)
 ## 👏 How to Contribute
 
 We welcome contributions from the community to improve and expand the Awell Score library. Here's how you can get involved:
+
+> Cutting a new version of the package? See [RELEASING.md](./RELEASING.md) — a push to `main` does not publish to npm.
 
 ### Adding a new Score
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,129 @@
+# Releasing
+
+`@awell-health/awell-score` is published to npm by
+[`.github/workflows/publish.yml`](./.github/workflows/publish.yml), which runs
+when a **GitHub Release is published**. Pushing to `main` never publishes.
+
+What a push to `main` *does* do, once lint/`tsc`/jest are green, is move the
+version to the next release candidate and leave a draft release ready for you in
+the [Releases tab](../../releases). Shipping is then one click.
+
+## The default path: a release candidate
+
+Merge a PR to `main` and the `release` job in
+[`test.yml`](./.github/workflows/test.yml):
+
+1. Bumps `package.json` to the next rc — `1.1.8` becomes `1.1.9-rc.0`,
+   `1.1.9-rc.0` becomes `1.1.9-rc.1` — and commits that to `main` as
+   `chore: bump version to vX`.
+2. Deletes the previous rc's draft, since it was superseded without ever
+   shipping.
+3. Drafts a release for the new version, marked as a prerelease, with the top
+   section of [CHANGELOG.md](./CHANGELOG.md) and the merged-PR list as its notes.
+
+Publish that draft and the rc goes to npm under the **`rc` dist-tag**, so
+consumers can `yarn add @awell-health/awell-score@rc` to try it while
+`npm install @awell-health/awell-score` still resolves to the last stable
+version.
+
+## Choosing the bump yourself
+
+The rc bump only happens when a push leaves the version untouched. Set the
+version in your PR and CI takes it as given — that is the whole override
+mechanism, and it shows up in the PR diff where reviewers can see it.
+
+| You want | Run in your PR branch | `1.1.8` becomes |
+| --- | --- | --- |
+| The next rc (what CI does anyway) | `yarn bump` | `1.1.9-rc.0` |
+| A minor release | `yarn bump:minor` | `1.2.0-rc.0` |
+| A major release | `yarn bump:major` | `2.0.0-rc.0` |
+| To cut the stable release | `yarn bump:release` | `1.1.9` |
+
+Commit the `package.json` change along with your work. These are thin wrappers
+around `npm version <level> --preid rc --no-git-tag-version`; they only edit the
+manifest, and never tag or commit.
+
+`yarn bump:minor` from `1.1.9-rc.3` gives `1.2.0-rc.0`, so you can redirect a
+release line at any point before it ships. Once you are on a line, ordinary
+merges keep incrementing within it: `1.2.0-rc.0` → `1.2.0-rc.1` → …
+
+## Cutting a stable release
+
+1. In a PR, run `yarn bump:release`. From any rc on the line this drops the
+   suffix — `1.2.0-rc.4` becomes `1.2.0` — and from a stable version it moves to
+   the next patch.
+2. Roll the `## Unreleased` heading in [CHANGELOG.md](./CHANGELOG.md) to the
+   version number.
+3. Merge. CI leaves the version alone and drafts `v1.2.0` as a normal (non-pre)
+   release.
+4. Publish the draft. Check the **target commit** first — a draft has no tag yet,
+   only a target, so the tag is created wherever the target points at the moment
+   you publish.
+5. `gh run watch`, then confirm with
+   `npm view @awell-health/awell-score version`.
+
+Publishing by hand works identically, as long as the tag matches `package.json`:
+
+```bash
+gh release create v1.2.0 --target main --title v1.2.0 --notes "See CHANGELOG.md"
+```
+
+The `v` prefix is required — every tag in this repo uses it, and `publish.yml`
+checks for it.
+
+## Guardrails
+
+**The tag and `package.json` must agree.** `publish.yml` fails before installing
+anything if they do not:
+
+```
+tag v1.1.9 does not match package.json version 1.1.8
+```
+
+That means the release was cut from a commit whose `package.json` says something
+else. Point the release at the right commit, or fix `package.json` on `main`
+first. This is the check that stops the drift behind this repo's
+`bump to correct version` / `make the version in line with what's in github`
+commits. It also means the publish step no longer rewrites the version from the
+tag — `package.json` is the source of truth and the guard proves the tag follows
+it.
+
+**Prereleases cannot hijack `latest`.** The publish step reads the version and
+sends anything containing a hyphen to the `rc` dist-tag. (The older `beta`
+dist-tag, at `1.0.8-beta12`, was set outside this workflow.)
+
+**The draft must be published by a person.** The draft is created with the
+built-in `GITHUB_TOKEN`, and events raised by that token do not trigger further
+workflows. If you ever make this publish automatically using that token, the npm
+publish will silently never run.
+
+## The `RELEASE_BOT_TOKEN` secret
+
+`main` requires a pull request with one approval, and **`github-actions[bot]`
+cannot be granted a bypass** — classic branch protection only accepts users,
+teams, and installable GitHub Apps in "Allow specified actors to bypass required
+pull requests", and the Actions bot is none of those. Its push is rejected with
+`protected branch hook declined`.
+
+So the `release` job checks out with `RELEASE_BOT_TOKEN` and falls back to the
+built-in token, which cannot push here. Create that secret with a token
+belonging to someone who *can* bypass — repository admins always can, as can the
+`awell-health/awell-developers` team:
+
+1. Create a fine-grained personal access token scoped to this repository with
+   **Contents: read and write**.
+2. Add it as the repository secret `RELEASE_BOT_TOKEN` (Settings → Secrets and
+   variables → Actions).
+
+Until that secret exists, everything else still works — tests run, and you can
+release by bumping the version in a PR yourself and cutting the release by hand.
+Only the automatic rc bump needs it.
+
+A personal token ties releases to one person's account and expires. The durable
+version of this is a GitHub App with `contents: write`, installed on the repo and
+added to the bypass list (Apps *can* be added there), minting a token per run via
+`actions/create-github-app-token`. Worth doing if this outgrows one maintainer.
+
+Note the trade-off that comes with a PAT: unlike the built-in token, a PAT push
+**does** retrigger workflows, which is why the bump commit carries `[skip ci]`.
+Remove that and the job will bump forever.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "lint": "eslint --config eslint.config.js",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
     "test": "jest ",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "bump": "npm version prerelease --preid rc --no-git-tag-version",
+    "bump:minor": "npm version preminor --preid rc --no-git-tag-version",
+    "bump:major": "npm version premajor --preid rc --no-git-tag-version",
+    "bump:release": "npm version patch --no-git-tag-version"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Why

Pushing to `main` never published, and nothing in the repo wrote down that publishing a **GitHub Release** is what ships to npm. So the version in `package.json` drifted from the registry — hence `bump to correct version`, `make the version in line with what's in github`, `make version the same as npm packadge` in the history.

There was also no `RELEASING.md`, no `CONTRIBUTING.md`, and no mention of releasing in the README.

## What changes

**Pushes to `main` now move the version to the next rc and leave a draft release ready to publish.** The `release` job in `test.yml` (gated on `needs: test`) bumps, commits, deletes the superseded rc's draft, and drafts the new version with the top changelog section plus the merged-PR list as notes.

**`yarn bump` and friends** wrap `npm version <level> --preid rc --no-git-tag-version`, which gives exactly the semver increment rules we want with no new dependency:

| Run in your PR | `1.1.8` → | `1.1.9-rc.3` → |
| --- | --- | --- |
| `yarn bump` | `1.1.9-rc.0` | `1.1.9-rc.4` |
| `yarn bump:minor` | `1.2.0-rc.0` | `1.2.0-rc.0` |
| `yarn bump:major` | `2.0.0-rc.0` | `2.0.0-rc.0` |
| `yarn bump:release` | `1.1.9` | `1.1.9` |

`patch` on a prerelease *drops* the suffix rather than incrementing, so `bump:release` cuts stable from a patch, minor, or major line with one command.

**Setting the version in a PR is the whole override mechanism.** The rc bump only fires when a push left the version untouched, so `yarn bump:minor` in your branch is the intent declaration — visible in the diff, no new file format, no separate CI path. This is the changeset-shaped part, without changesets.

**Two guardrails, and one simplification that follows from them:**

- `publish.yml` fails before installing anything if the release tag and `package.json` disagree. That is the drift check.
- Because the guard proves they match, the old `yarn version "$release_version"` rewrite is gone — `package.json` is the source of truth.
- Release candidates publish to the `rc` dist-tag, so `1.1.9-rc.0` cannot become what `npm install` resolves to.

## Before merging: create `RELEASE_BOT_TOKEN`

`main` requires a PR with one approval, and **`github-actions[bot]` cannot be granted a bypass** — classic branch protection only accepts users, teams, and installable GitHub Apps, and the Actions bot is none of those. Its push is rejected with `protected branch hook declined`.

The job checks out with `secrets.RELEASE_BOT_TOKEN`, falling back to the built-in token. Create it as a fine-grained PAT scoped to this repo with **Contents: read and write**, owned by someone who can bypass (repo admins, or `awell-health/awell-developers`).

Until that secret exists nothing breaks: tests still run and you can release by bumping in a PR and cutting the release by hand. Only the automatic rc bump needs it. `RELEASING.md` covers the GitHub App upgrade path, which is the durable version.

Note the PAT trade-off, documented in the workflow: unlike the built-in token a PAT push retriggers workflows, which is why the bump commit carries `[skip ci]`.

## Verification

- Both workflows parse; every `run` block passes `bash -n`.
- The bump logic was simulated against a real git repo across five pushes — ordinary merge, second merge, `bump:minor` mid-flight, merge after the minor, `bump:release` — bumping, respecting, and staying on the correct line each time.
- The tag guard was checked against this repo: `v1.1.8` passes, `v1.1.9` fails while `package.json` says 1.1.8, and an unprefixed `1.1.8` fails.
- `gh release list` lookups return cleanly for both existing and non-existent tags (empty, exit 0), so they will not trip `bash -e`.

The `release` job only fires on pushes to `main`, so it cannot be exercised from this branch — its first real run is on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdWziF3fQufm9mkfCb5JPQ