### PR TITLE
fix(ci): open a pull request when the bump cannot reach main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,45 +52,81 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           # main requires a pull request, and github-actions[bot] cannot be
-          # granted a bypass, so pushing the bump needs a token belonging to
-          # someone who can — see RELEASING.md. Falls back to the built-in token,
-          # which will fail the push on a protected branch.
+          # granted a bypass, so pushing the bump directly needs a token belonging
+          # to someone who can — see RELEASING.md. Without RELEASE_BOT_TOKEN this
+          # falls back to the built-in token, the push is rejected, and the step
+          # below routes the bump through a pull request instead.
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Bump to the next release candidate
         id: bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           previous=$(git show "${{ github.event.before }}:package.json" 2>/dev/null | jq -r .version || true)
           current=$(jq -r .version package.json)
 
+          # The draft must point at the commit whose package.json carries the
+          # version — publish.yml checks the tag against it.
+          emit() {
+            echo "version=$1" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          }
+
           if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
             echo "::notice::This push set the version to $current by hand; leaving it as is."
-          else
-            npm version prerelease --preid rc --no-git-tag-version >/dev/null
-            current=$(jq -r .version package.json)
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            # [skip ci] matters when RELEASE_BOT_TOKEN is a PAT: unlike the
-            # built-in token, a PAT push retriggers workflows, and without this
-            # the bump would bump itself forever.
-            git commit -am "chore: bump version to v$current [skip ci]"
-            git push origin "HEAD:$GITHUB_REF_NAME"
-            echo "::notice::Bumped $previous -> $current."
-            echo "superseded=$previous" >> "$GITHUB_OUTPUT"
+            emit "$current"
+            exit 0
           fi
 
-          echo "version=$current" >> "$GITHUB_OUTPUT"
-          # The draft must point at the bump commit, not at the pushed commit —
-          # publish.yml checks the tag against package.json at the tagged commit.
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          npm version prerelease --preid rc --no-git-tag-version >/dev/null
+          version=$(jq -r .version package.json)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # [skip ci] matters when RELEASE_BOT_TOKEN is a PAT: unlike the built-in
+          # token, a PAT push retriggers workflows, and without this the bump
+          # would bump itself forever.
+          git commit -qam "chore: bump version to v$version [skip ci]"
 
+          if git push origin "HEAD:$GITHUB_REF_NAME"; then
+            echo "::notice::Bumped $current -> $version."
+            echo "superseded=$current" >> "$GITHUB_OUTPUT"
+            emit "$version"
+            exit 0
+          fi
+
+          # Protected branch. Open a pull request for the bump instead of failing
+          # the run. Merging it re-enters this job, which then sees the version
+          # already set, leaves it alone, and drafts the release. No draft is made
+          # now, because the version has not landed on the release branch yet.
+          branch="chore/bump-v$version"
+          git push -qf origin "HEAD:$branch"
+
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            # printf rather than a multi-line string, so YAML indentation does not
+            # end up in the pull request body.
+            body=$(printf '%s\n\n%s\n\n%s' \
+              "Automated release-candidate bump from $current to $version." \
+              "Merging this drafts the \`v$version\` release; publishing that draft ships it to npm. See [RELEASING.md](./RELEASING.md)." \
+              "This arrived as a pull request because the bump could not be pushed to \`$GITHUB_REF_NAME\` directly. Setting the \`RELEASE_BOT_TOKEN\` secret removes this extra step.")
+
+            gh pr create --base "$GITHUB_REF_NAME" --head "$branch" \
+              --title "chore: bump version to v$version" --body "$body"
+          fi
+
+          echo "::warning::Could not push to $GITHUB_REF_NAME, so v$version was opened as a pull request. Set RELEASE_BOT_TOKEN to bump directly — see RELEASING.md."
+
+      # Skipped when the bump went out as a pull request: the version is not on the
+      # release branch yet, so there is nothing valid to tag.
       - name: Refresh the draft release
+        if: steps.bump.outputs.version != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.bump.outputs.version }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,19 +105,21 @@ teams, and installable GitHub Apps in "Allow specified actors to bypass required
 pull requests", and the Actions bot is none of those. Its push is rejected with
 `protected branch hook declined`.
 
-So the `release` job checks out with `RELEASE_BOT_TOKEN` and falls back to the
-built-in token, which cannot push here. Create that secret with a token
-belonging to someone who *can* bypass — repository admins always can, as can the
+**Without the secret, the release job still works** — it just takes one more
+click. When the direct push is rejected, it pushes `chore/bump-v<version>` and
+opens a pull request for the bump instead of failing. Merging that PR re-enters
+the job, which sees the version already set, leaves it alone, and drafts the
+release. So the only difference the secret makes is whether you merge a bump PR
+or not.
+
+To skip that step, create the secret with a token belonging to someone who *can*
+bypass the branch protection — repository admins always can, as can the
 `awell-health/awell-developers` team:
 
 1. Create a fine-grained personal access token scoped to this repository with
    **Contents: read and write**.
 2. Add it as the repository secret `RELEASE_BOT_TOKEN` (Settings → Secrets and
    variables → Actions).
-
-Until that secret exists, everything else still works — tests run, and you can
-release by bumping the version in a PR yourself and cutting the release by hand.
-Only the automatic rc bump needs it.
 
 A personal token ties releases to one person's account and expires. The durable
 version of this is a GitHub App with `contents: write`, installed on the repo and


### PR DESCRIPTION
## The failure

#97 merged, and the `release` job did exactly what I warned it would:

```
[main 8656469] chore: bump version to v1.1.9-rc.0 [skip ci]
 2 files changed, 3 insertions(+), 3 deletions(-)
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
Error: Process completed with exit code 1.
```

Two consequences, one of which I underrated:

1. Every merge to `main` shows a red X.
2. Because the bump step *failed*, the "Refresh the draft release" step was **skipped** — so no draft either. The whole release path was dead, not degraded.

I had said the missing `RELEASE_BOT_TOKEN` would leave "everything else still working". That was wrong: a failing step takes the rest of the job with it.

## The fix

The job no longer treats a rejected push as fatal. If it can't push to `main`, it pushes `chore/bump-v<version>` and opens a pull request for the bump.

What makes this clean rather than a bolt-on is the guard that's already there. Merging the bump PR re-enters the job, which sees that *this push set the version by hand*, leaves it alone, and drafts the release. The fallback and the direct path converge on the same end state:

| | with `RELEASE_BOT_TOKEN` | without |
| --- | --- | --- |
| bump lands | pushed to `main` | bump PR you merge |
| draft created | same run | on the merge run |
| result | `v1.1.9-rc.0` drafted | `v1.1.9-rc.0` drafted |

Drafting is skipped on the fallback run itself (`if: steps.bump.outputs.version != ''`), because the version isn't on `main` yet and `publish.yml` checks the tag against `package.json` at the tagged commit — a draft then would be invalid by construction.

So `RELEASE_BOT_TOKEN` becomes an optimization that saves a merge, not a prerequisite. RELEASING.md now says so instead of claiming it's required.

## Verification

- YAML parses; both `run` blocks pass `bash -n`; the draft step's `if` guard is in place.
- The fallback was exercised against a real rejection: a local bare repo with a `pre-receive` hook that mimics GH006 on `main`. The direct push was refused, and `chore/bump-v1.1.9-rc.0` was created on the remote as expected.
- The PR body is built with `printf` rather than a YAML multi-line string, so workflow indentation doesn't leak into it.

## After this merges

The merge itself will exercise the new path — expect a `chore: bump version to v1.1.9-rc.0` PR to appear. Merging that should draft `v1.1.9-rc.0`, which is the first real end-to-end test of the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdWziF3fQufm9mkfCb5JPQ