### PR TITLE
chore: release 1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.9
 
 - Added optional `licensing_status` and `license_contact` fields to instrument
   definitions and the API schema output (`apiSchema`). Both are additive and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@awell-health/awell-score",
-  "version": "1.1.9-rc.0",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@awell-health/awell-score",
-      "version": "1.1.9-rc.0",
+      "version": "1.1.9",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/awell-score",
-  "version": "1.1.9-rc.0",
+  "version": "1.1.9",
   "description": "Library of Medical Score functions",
   "packageManager": "yarn@4.6.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Cuts stable **1.1.9** from `1.1.9-rc.0`.

## What's in it

- `yarn bump:release` → `package.json` (and `package-lock.json`) go from `1.1.9-rc.0` to `1.1.9`.
- `CHANGELOG.md`'s `## Unreleased` heading is renamed to `## 1.1.9`, carrying the `licensing_status` / `license_contact` addition and the PANSS removal.

## What happens on merge

The `release` job sees this push set the version by hand, so it leaves `1.1.9` alone rather than bumping to `1.1.10-rc.0`, and drafts **`v1.1.9`** as a normal release — no `--prerelease` flag, because the version has no hyphen.

Publishing that draft runs `publish.yml`, which checks the tag against `package.json` (`v1.1.9` vs `1.1.9` ✓), builds, and publishes to the **`latest`** dist-tag. That is the first stable release to go through the new flow.

The heading rename matters more than it looks: the draft's notes come from `awk '/^## /{n++; next} n==1'`, i.e. the *first* `## ` section. Leaving an empty `## Unreleased` above it would have produced an empty release body. Verified the extraction returns both changelog entries.

## After merging

Two drafts will exist: the new `v1.1.9` and the stale `v1.1.9-rc.0`, which was never published. The stale-draft cleanup only runs on the automatic bump path, not when the version is hand-set, so delete the rc draft manually:

```bash
gh release delete v1.1.9-rc.0 --yes
```

That gap is worth closing in the workflow so it does not recur on every stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdWziF3fQufm9mkfCb5JPQ