### PR TITLE
fix(ci): delete the superseded draft when the version is hand-set too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,10 @@ jobs:
 
           if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
             echo "::notice::This push set the version to $current by hand; leaving it as is."
+            # The version this replaces is superseded just as much as on the
+            # automatic path — `yarn bump:release` from 1.1.9-rc.0 to 1.1.9 leaves
+            # the rc's draft behind otherwise, on every single stable release.
+            echo "superseded=$previous" >> "$GITHUB_OUTPUT"
             emit "$current"
             exit 0
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,10 +52,13 @@ merges keep incrementing within it: `1.2.0-rc.0` → `1.2.0-rc.1` → …
 1. In a PR, run `yarn bump:release`. From any rc on the line this drops the
    suffix — `1.2.0-rc.4` becomes `1.2.0` — and from a stable version it moves to
    the next patch.
-2. Roll the `## Unreleased` heading in [CHANGELOG.md](./CHANGELOG.md) to the
-   version number.
-3. Merge. CI leaves the version alone and drafts `v1.2.0` as a normal (non-pre)
-   release.
+2. **Rename** the `## Unreleased` heading in [CHANGELOG.md](./CHANGELOG.md) to the
+   version number — do not leave an empty `## Unreleased` above it. The draft's
+   notes are the *first* `## ` section, so an empty one ships an empty release
+   body. Add a fresh `## Unreleased` next time there is something to record.
+3. Merge. CI leaves the version alone, deletes the superseded rc's draft, and
+   drafts `v1.2.0` as a normal (non-pre) release. A superseded version that was
+   actually *published* is never deleted, only an unshipped draft.
 4. Publish the draft. Check the **target commit** first — a draft has no tag yet,
    only a target, so the tag is created wherever the target points at the moment
    you publish.


### PR DESCRIPTION
Re-opens a fix that got stranded: it was pushed to `fix/release-bump-fallback` after #100 had already been merged, so #100 landed with only the fallback commit and this never reached `main`. Verified — `main`'s `test.yml` emits `superseded` in the automatic-bump branch only.

## The gap

The stale-draft cleanup runs only on the automatic rc path. When the version is set by hand — which is every stable release — the previous version's draft is left behind:

`yarn bump:release` takes `1.1.9-rc.0` → `1.1.9`, and the `v1.1.9-rc.0` draft sits in the Releases tab until someone deletes it. That happened on the 1.1.9 release and had to be cleaned up manually. Once per stable release, accumulating.

## The fix

Emit `superseded` on the hand-set path as well. The delete stays guarded to `state = draft`, which is the part that matters — a superseded version that actually shipped is never touched. Simulated across the cases that will really occur:

| Scenario | superseded | its state | action |
| --- | --- | --- | --- |
| `bump:release` 1.1.9-rc.0 → 1.1.9, rc unshipped | 1.1.9-rc.0 | draft | **delete** |
| `bump:minor` from published 1.1.9 | 1.1.9 | published | keep |
| rc *was* published to npm, then cut stable | 1.1.9-rc.0 | published | keep |
| automatic rc bump, prior rc a draft | 1.1.9-rc.0 | draft | **delete** |
| nothing superseded | — | — | keep |

Rows 2 and 3 are the ones worth checking in review: those are published releases, and deleting one would orphan its tag.

## Also

RELEASING.md now says the changelog heading must be **renamed**, not have an empty `## Unreleased` left above it. The draft body comes from the first `## ` section, so an empty one ships a release with empty notes. I nearly did that while preparing 1.1.9.

## Context

1.1.9 is live on npm (`latest: 1.1.9`, published 23:02) — the full chain worked, so this is housekeeping for the next release rather than anything urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdWziF3fQufm9mkfCb5JPQ